### PR TITLE
fix broken build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         FHIR_ENDPOINT: ${FHIR_ENDPOINT}
         NAMESPACE: ${NAMESPACE}
     restart: always
-    command: --check-caps false
+#    command: --check-caps false
     ports: 
       - 32782:1972
       - 32783:52773


### PR DESCRIPTION
parsing D:\GitHub\fhir-profile-validation\docker-compose.yml: yaml: unmarshal errors: 
  line 35: mapping key "command" already defined at line 26